### PR TITLE
More Highlighting Bugfixes (which also changed RunDialogueMC)

### DIFF
--- a/Assets/Scenes/CoffeeScene.unity
+++ b/Assets/Scenes/CoffeeScene.unity
@@ -3086,7 +3086,7 @@ CanvasGroup:
   m_Enabled: 1
   m_Alpha: 0
   m_Interactable: 1
-  m_BlocksRaycasts: 1
+  m_BlocksRaycasts: 0
   m_IgnoreParentGroups: 0
 --- !u!1 &1090745762
 GameObject:

--- a/Assets/Scripts/Dialogue/RunDialogueMC.cs
+++ b/Assets/Scripts/Dialogue/RunDialogueMC.cs
@@ -9,7 +9,9 @@ public class RunDialogueMC : MonoBehaviour
     public string dialogueToRun;
     public void OnMouseDown()
     {
-        if (!dialogueRunner.IsDialogueRunning)
+        // Bottom URL links to how to block UI stuff
+        // https://answers.unity.com/questions/822273/how-to-prevent-raycast-when-clicking-46-ui.html?childToView=862598#answer-862598
+        if (!dialogueRunner.IsDialogueRunning && !UnityEngine.EventSystems.EventSystem.current.IsPointerOverGameObject())
         {
             dialogueRunner.StartDialogue(dialogueToRun);
             Debug.Log("running" + dialogueToRun);

--- a/Assets/Scripts/Levels/HidePuzzle.cs
+++ b/Assets/Scripts/Levels/HidePuzzle.cs
@@ -10,5 +10,6 @@ public class HidePuzzle : MonoBehaviour
     public void Hide()
     {
         puzzlePanel.GetComponent<CanvasGroup>().alpha = 0;
+        puzzlePanel.GetComponent<CanvasGroup>().blocksRaycasts = false;
     }
 }

--- a/Assets/Scripts/Levels/HighlightSprite.cs
+++ b/Assets/Scripts/Levels/HighlightSprite.cs
@@ -24,7 +24,9 @@ public class HighlightSprite : MonoBehaviour
     }
     public void OnMouseOver()
     {
-        if (interact.tag == "Item" && diaRun != null && !diaRun.IsDialogueRunning)
+        // Bottom URL links to how to block UI stuff
+        // https://answers.unity.com/questions/822273/how-to-prevent-raycast-when-clicking-46-ui.html?childToView=862598#answer-862598
+        if (interact.tag == "Item" && diaRun != null && !diaRun.IsDialogueRunning && !UnityEngine.EventSystems.EventSystem.current.IsPointerOverGameObject())
         {
             interact.GetComponent<SpriteRenderer>().color = Color.yellow;
             //interact.GetComponent<SpriteRenderer>().sprite = Sprite1;

--- a/Assets/Scripts/Levels/ShowPuzzle.cs
+++ b/Assets/Scripts/Levels/ShowPuzzle.cs
@@ -10,5 +10,6 @@ public class ShowPuzzle : MonoBehaviour
     public void Puzzle()
     {
         puzzlePanel.GetComponent<CanvasGroup>().alpha = 1;
+        puzzlePanel.GetComponent<CanvasGroup>().blocksRaycasts = true;
     }
 }


### PR DESCRIPTION
Summary: Items can no longer be clicked on/highlighted when located
behind UI elements. Also, the Coffee Puzzle panel will no longer block
raycasts while its Canvas Group alpha is set to 0.

RunDialogueMC.cs AND HighlightSprite.cs
- Both of these scripts now check for if the pointer is over the
EventSystem.current GameObject. AFAIK, this means UI stuff, so if the
mouse is over UI stuff (while it is also over the Item that can be
clicked), it will no longer trigger a selection, nor will it highlight
the item in question.

HidePuzzle.cs AND ShowPuzzle.cs
- The CanvasGroup for the puzzlePanel has its "blocksRaycasts" field set
to false (when hidden) and true (when shown) respectively.

CoffeeScene.unity
- Made the CanvasGroup in the "make ur coffe here" GameObject have
Blocks Raycasts set to false at start.