### PR TITLE
UI Blocker for the Coffee Level, and Dialogue/Checking for the Tutorial Level

### DIFF
--- a/Assets/Art/Levels/Level2_GravetoCoffee/Objects/pebbles_temp.png.meta
+++ b/Assets/Art/Levels/Level2_GravetoCoffee/Objects/pebbles_temp.png.meta
@@ -1,0 +1,92 @@
+fileFormatVersion: 2
+guid: 77bac97b34941ab468788fa5551627e0
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/Levels/Level3_CoffeeScene/temp_letter_to_john.png.meta
+++ b/Assets/Art/Levels/Level3_CoffeeScene/temp_letter_to_john.png.meta
@@ -1,0 +1,92 @@
+fileFormatVersion: 2
+guid: b497de57c1c296b4b80acc1e22634dc4
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/Levels/Level3_CoffeeScene/temp_read_letter.png.meta
+++ b/Assets/Art/Levels/Level3_CoffeeScene/temp_read_letter.png.meta
@@ -1,0 +1,92 @@
+fileFormatVersion: 2
+guid: 153a32d3af811014ba209fa0fb552dbd
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/CoffeeScene.unity
+++ b/Assets/Scenes/CoffeeScene.unity
@@ -704,7 +704,7 @@ RectTransform:
   - {fileID: 1783188770}
   - {fileID: 400418771}
   m_Father: {fileID: 2136782267}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -741,7 +741,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 258097537}
   m_Enabled: 1
-  m_Alpha: 1
+  m_Alpha: 0
   m_Interactable: 1
   m_BlocksRaycasts: 0
   m_IgnoreParentGroups: 0
@@ -3116,7 +3116,7 @@ RectTransform:
   - {fileID: 1094579958}
   - {fileID: 506077594}
   m_Father: {fileID: 2136782267}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4511,7 +4511,7 @@ RectTransform:
   - {fileID: 649099269}
   - {fileID: 1330951188}
   m_Father: {fileID: 2136782267}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5930,6 +5930,93 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2069865092}
   m_CullTransparentMesh: 0
+--- !u!1 &2082096715
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2082096716}
+  - component: {fileID: 2082096719}
+  - component: {fileID: 2082096718}
+  - component: {fileID: 2082096717}
+  m_Layer: 5
+  m_Name: Blocker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2082096716
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082096715}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2136782267}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.14951, y: -0.000030518}
+  m_SizeDelta: {x: 2092.0679, y: 1080}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &2082096717
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082096715}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 1
+  m_BlocksRaycasts: 0
+  m_IgnoreParentGroups: 0
+--- !u!114 &2082096718
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082096715}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 0.105882354}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2082096719
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082096715}
+  m_CullTransparentMesh: 0
 --- !u!1 &2119695928
 GameObject:
   m_ObjectHideFlags: 0
@@ -6224,6 +6311,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
+  - {fileID: 2082096716}
   - {fileID: 258097540}
   - {fileID: 1087914912}
   - {fileID: 1647846074}
@@ -6293,7 +6381,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: -1
   m_TargetDisplay: 0
 --- !u!4 &5299666707177996259
 Transform:

--- a/Assets/Scenes/Tutorial.unity
+++ b/Assets/Scenes/Tutorial.unity
@@ -426,9 +426,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f257052c88782c4ca692c429ae92f3f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  droppers: []
-  coffee: 0
-  creamPuzzle: {fileID: 0}
+  isDragging: 0
 --- !u!114 &38536882
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1394,7 +1392,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 65.67, y: 0.35, z: -52.78}
   m_LocalScale: {x: 5, y: 5, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1357284621}
   m_Father: {fileID: 493771255}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
@@ -1666,9 +1665,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f257052c88782c4ca692c429ae92f3f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  droppers: []
-  coffee: 0
-  creamPuzzle: {fileID: 0}
+  isDragging: 0
 --- !u!114 &464217192
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3856,9 +3853,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f257052c88782c4ca692c429ae92f3f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  droppers: []
-  coffee: 0
-  creamPuzzle: {fileID: 0}
+  isDragging: 0
 --- !u!114 &1053138216
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4029,9 +4024,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f257052c88782c4ca692c429ae92f3f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  droppers: []
-  coffee: 0
-  creamPuzzle: {fileID: 0}
+  isDragging: 0
 --- !u!114 &1134953574
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4302,6 +4295,82 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
+--- !u!1 &1357284620
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1357284621}
+  - component: {fileID: 1357284623}
+  - component: {fileID: 1357284622}
+  - component: {fileID: 1357284624}
+  m_Layer: 0
+  m_Name: Gate Approach
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1357284621
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1357284620}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: -0.91}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 454199816}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1357284622
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1357284620}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306fed8abd2cb4144873c907be61457d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialogueRunner: {fileID: 739597929}
+  customVariableStorage: {fileID: 739597928}
+--- !u!65 &1357284623
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1357284620}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 9.26248, y: 2.9800155, z: 19.275444}
+  m_Center: {x: 0.73496324, y: 0.12157726, z: -9.137722}
+--- !u!54 &1357284624
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1357284620}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1399871819
 GameObject:
   m_ObjectHideFlags: 0
@@ -4575,9 +4644,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f257052c88782c4ca692c429ae92f3f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  droppers: []
-  coffee: 0
-  creamPuzzle: {fileID: 0}
+  isDragging: 0
 --- !u!114 &1514995537
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6398,9 +6465,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f257052c88782c4ca692c429ae92f3f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  droppers: []
-  coffee: 0
-  creamPuzzle: {fileID: 0}
+  isDragging: 0
 --- !u!114 &2602872232497341172
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Levels/HidePuzzle.cs
+++ b/Assets/Scripts/Levels/HidePuzzle.cs
@@ -11,5 +11,9 @@ public class HidePuzzle : MonoBehaviour
     {
         puzzlePanel.GetComponent<CanvasGroup>().alpha = 0;
         puzzlePanel.GetComponent<CanvasGroup>().blocksRaycasts = false;
+        // allow background interactions
+        GameObject blocker = GameObject.Find("Canvas/Blocker");
+        blocker.GetComponent<CanvasGroup>().alpha = 0;
+        blocker.GetComponent<CanvasGroup>().blocksRaycasts = false;
     }
 }

--- a/Assets/Scripts/Levels/HidePuzzle.cs
+++ b/Assets/Scripts/Levels/HidePuzzle.cs
@@ -13,7 +13,10 @@ public class HidePuzzle : MonoBehaviour
         puzzlePanel.GetComponent<CanvasGroup>().blocksRaycasts = false;
         // allow background interactions
         GameObject blocker = GameObject.Find("Canvas/Blocker");
-        blocker.GetComponent<CanvasGroup>().alpha = 0;
-        blocker.GetComponent<CanvasGroup>().blocksRaycasts = false;
+        if (blocker)
+        {
+            blocker.GetComponent<CanvasGroup>().alpha = 0;
+            blocker.GetComponent<CanvasGroup>().blocksRaycasts = false;
+        }
     }
 }

--- a/Assets/Scripts/Levels/ShowPuzzle.cs
+++ b/Assets/Scripts/Levels/ShowPuzzle.cs
@@ -13,7 +13,10 @@ public class ShowPuzzle : MonoBehaviour
         puzzlePanel.GetComponent<CanvasGroup>().blocksRaycasts = true;
         // block background interactions
         GameObject blocker = GameObject.Find("Canvas/Blocker");
-        blocker.GetComponent<CanvasGroup>().alpha = 1;
-        blocker.GetComponent<CanvasGroup>().blocksRaycasts = true;
+        if (blocker)
+        {
+            blocker.GetComponent<CanvasGroup>().alpha = 1;
+            blocker.GetComponent<CanvasGroup>().blocksRaycasts = true;
+        }
     }
 }

--- a/Assets/Scripts/Levels/ShowPuzzle.cs
+++ b/Assets/Scripts/Levels/ShowPuzzle.cs
@@ -11,5 +11,9 @@ public class ShowPuzzle : MonoBehaviour
     {
         puzzlePanel.GetComponent<CanvasGroup>().alpha = 1;
         puzzlePanel.GetComponent<CanvasGroup>().blocksRaycasts = true;
+        // block background interactions
+        GameObject blocker = GameObject.Find("Canvas/Blocker");
+        blocker.GetComponent<CanvasGroup>().alpha = 1;
+        blocker.GetComponent<CanvasGroup>().blocksRaycasts = true;
     }
 }

--- a/Assets/Scripts/Levels/Tutorial/GateApproach.cs
+++ b/Assets/Scripts/Levels/Tutorial/GateApproach.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Yarn.Unity;
+
+public class GateApproach : MonoBehaviour
+{
+	public DialogueRunner dialogueRunner;
+	public VariableStorageBehaviour customVariableStorage;
+	
+	private void OnTriggerEnter(Collider other)
+	{
+		// do not run the rest of the function if dialogueRunner or customVariableStorage is null
+		if (dialogueRunner == null || customVariableStorage == null)
+		{
+			return;
+		}
+		// if collision is with player...
+		if (other.gameObject.CompareTag("Player"))
+		{
+			// access the puzzle yarn value
+			Yarn.Value puzzle = customVariableStorage.GetValue("$puzzle");
+			if (puzzle != null && puzzle.AsNumber == 1)
+			{
+				// run gate_approach node if puzzle is 1
+				if (!dialogueRunner.IsDialogueRunning)
+				{
+					dialogueRunner.StartDialogue("gate_approach");
+				}
+			}
+		}
+	}
+}

--- a/Assets/Scripts/Levels/Tutorial/GateApproach.cs.meta
+++ b/Assets/Scripts/Levels/Tutorial/GateApproach.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 306fed8abd2cb4144873c907be61457d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Levels/Tutorial/Yarn/Checkpoint1.yarn
+++ b/Assets/Scripts/Levels/Tutorial/Yarn/Checkpoint1.yarn
@@ -8,24 +8,40 @@ tags:
 title: Flower1
 ---
 <<ChangeSpeaker Player>>
-    Oh! That's pretty!
-    <<Destroy FlowerFieldA>>
+    <<if visited("prologue_doneExplore") is true>>
+        Oh! That's pretty!
+        <<Destroy FlowerFieldA>>
+    <<else>>
+        It's a flower.
+    <<endif>>
 ===
 title: Flower2
 ---
 <<ChangeSpeaker Player>>
-    This one wil look nice on the grave.
-    <<Destroy FlowerFieldB>>
+    <<if visited("prologue_doneExplore") is true>>
+        This one wil look nice on the grave.
+        <<Destroy FlowerFieldB>>
+    <<else>>
+        I bet it would smell nice if I could smell.
+    <<endif>>
 ===
 title: Flower3
 ---
 <<ChangeSpeaker Player>>
-    How about this flower?
-    <<Destroy FlowerFieldC>>
+    <<if visited("prologue_doneExplore") is true>>
+        How about this flower?
+        <<Destroy FlowerFieldC>>
+    <<else>>
+        You’ll be replaced with a grave, one day.
+    <<endif>>
 ===
 title: Flower4
 ---
 <<ChangeSpeaker Player>>
-    I like this one!
-    <<Destroy FlowerFieldD>>
+    <<if visited("prologue_doneExplore") is true>>
+        I like this one!
+        <<Destroy FlowerFieldD>>
+    <<else>>
+        Not just some weed.
+    <<endif>>
 ===

--- a/Assets/Scripts/Levels/Tutorial/Yarn/gate.yarn
+++ b/Assets/Scripts/Levels/Tutorial/Yarn/gate.yarn
@@ -6,6 +6,22 @@ tags:
 
     The key fits! I can finally get out of here.
 
+    <<ChangeScene Gate Street>>
+
+<<else>>
+
+    <<ChangeSpeaker Player>>
+
+    The gate seems locked, maybe there is a key somewhere...
+
+<<endif>>
+
+===
+
+title: gate_approach
+tags:
+---
+<<if $puzzle is 1 and visited("gate_approach") is false>>
     <<ChangeSpeaker Gravekeeper>>
     What on earth?!
 
@@ -24,13 +40,6 @@ tags:
     ...Is there?
 
     I’m not sticking around to find out. I’m out.
-
-    <<ChangeScene Gate Street>>
-<<else>>
-
-    <<ChangeSpeaker Player>>
-
-    The gate seems locked, maybe there is a key somewhere...
 <<endif>>
 
 ===

--- a/Assets/Scripts/Levels/Tutorial/Yarn/gate.yarn
+++ b/Assets/Scripts/Levels/Tutorial/Yarn/gate.yarn
@@ -6,6 +6,25 @@ tags:
 
     The key fits! I can finally get out of here.
 
+    <<ChangeSpeaker Gravekeeper>>
+    What on earth?!
+
+    Last I looked, there were no flowers here.
+
+    No one’s bee in or out of this place. I’m the only one with the key.
+
+    Can it be?
+
+    No.
+
+    No, there’s no such thing.
+
+    ...
+
+    ...Is there?
+
+    I’m not sticking around to find out. I’m out.
+
     <<ChangeScene Gate Street>>
 <<else>>
 

--- a/Assets/Scripts/Levels/coffee level/coffee.asset
+++ b/Assets/Scripts/Levels/coffee level/coffee.asset
@@ -14,4 +14,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemName: Coffee
   itemDescription: 
-  icon: {fileID: 21300000, guid: e6f21dc702bb04541ab73a6e5a8ca0c4, type: 3}
+  icon: {fileID: 21300000, guid: 23e30819085165d468f6584831830a20, type: 3}

--- a/Assets/Scripts/Levels/coffee level/coffee.asset
+++ b/Assets/Scripts/Levels/coffee level/coffee.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cfb260ee78c558440961cc09e4521b96, type: 3}
-  m_Name: Coffee
+  m_Name: coffee
   m_EditorClassIdentifier: 
   itemName: Coffee
   itemDescription: 


### PR DESCRIPTION
- UI Blocker has been added for the Coffee Level. If any puzzle is being shown, and the blocker exists, then it will activate the blocker (make it visible (alpha = 1) and block raycasts). Otherwise, it will deactivate it.
- Checkpoint1.yarn verifies if the player has finished exploring before picking up flowers (i.e., by playing different dialogue)
- gate.yarn has a new node for when the player approaches the gate. This node is only triggered after the puzzle has been completed (and is only triggered once). This meant adding a new box collider to check for the player (new gameobject: Gate Approach).