### PR TITLE
Trash Refactoring stuff & some bug fixes

### DIFF
--- a/Assets/Scenes/CoffeeScene.unity
+++ b/Assets/Scenes/CoffeeScene.unity
@@ -3910,6 +3910,146 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 979082388}
   m_CullTransparentMesh: 0
+--- !u!1 &1070353867
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1070353870}
+  - component: {fileID: 1070353869}
+  - component: {fileID: 1070353868}
+  m_Layer: 0
+  m_Name: SoundManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!82 &1070353868
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1070353867}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!114 &1070353869
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1070353867}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f60d13a9252c793478747b67284726a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1070353870
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1070353867}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -35.5, y: 6.6, z: -4767.4985}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1087914911
 GameObject:
   m_ObjectHideFlags: 0
@@ -4634,6 +4774,7 @@ MonoBehaviour:
   - {fileID: 2480198943629176163, guid: 6ddf704bf49c1234dbd388804eb6081d, type: 3}
   - {fileID: 2480198943629176163, guid: f31dd384928c5664daee72c66300d9c4, type: 3}
   - {fileID: 2480198943629176163, guid: 36b18a323900b9741a4230cf6af708ad, type: 3}
+  - {fileID: 2480198943629176163, guid: 4190cc03f81b55b438f24739cb205d17, type: 3}
   textLanguage: 
   variableStorage: {fileID: 1124219127}
   dialogueUI: {fileID: 1124219126}

--- a/Assets/Scenes/Tutorial.unity
+++ b/Assets/Scenes/Tutorial.unity
@@ -2837,6 +2837,7 @@ MonoBehaviour:
   - {fileID: 2480198943629176163, guid: af93ea5d828c7d749839efaa58bfd55c, type: 3}
   - {fileID: 2480198943629176163, guid: 7041b33f729551746b273b54389b6d6e, type: 3}
   - {fileID: 2480198943629176163, guid: 9a753bbddbbd0ae4685eab4fa7cb2bab, type: 3}
+  - {fileID: 2480198943629176163, guid: 4190cc03f81b55b438f24739cb205d17, type: 3}
   textLanguage: 
   variableStorage: {fileID: 739597928}
   dialogueUI: {fileID: 739597927}
@@ -4392,6 +4393,51 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
+--- !u!1 &1315948063
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1315948064}
+  - component: {fileID: 1315948065}
+  m_Layer: 5
+  m_Name: Trash Slot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!224 &1315948064
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1315948063}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 1}
+  m_Children:
+  - {fileID: 1644062691}
+  m_Father: {fileID: 1467970841}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 267.99997, y: -202.25003}
+  m_SizeDelta: {x: 46.06554, y: 47.2915}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1315948065
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1315948063}
+  m_CullTransparentMesh: 0
 --- !u!1 &1357284620
 GameObject:
   m_ObjectHideFlags: 0
@@ -4725,6 +4771,7 @@ RectTransform:
   - {fileID: 1618137395}
   - {fileID: 606248082}
   - {fileID: 590583795}
+  - {fileID: 1315948064}
   m_Father: {fileID: 1946651272}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5245,6 +5292,130 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1631934917}
+  m_CullTransparentMesh: 0
+--- !u!1 &1644062690
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1644062691}
+  - component: {fileID: 1644062696}
+  - component: {fileID: 1644062695}
+  - component: {fileID: 1644062694}
+  - component: {fileID: 1644062693}
+  - component: {fileID: 1644062692}
+  m_Layer: 5
+  m_Name: Trash Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!224 &1644062691
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1644062690}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1315948064}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.0000019073, y: -0.00000095367}
+  m_SizeDelta: {x: 46.065536, y: 47.291496}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1644062692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1644062690}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 440031dc59553cf48b5037e0d6563aaa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialogueRunner: {fileID: 739597929}
+  trashOpened: {fileID: 21300000, guid: da2e945729ed47a4eb84424ad6d8d882, type: 3}
+  trashClosed: {fileID: 21300000, guid: c75df5d295ce42448baba6b66391977e, type: 3}
+--- !u!114 &1644062693
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1644062690}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!225 &1644062694
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1644062690}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &1644062695
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1644062690}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c75df5d295ce42448baba6b66391977e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1644062696
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1644062690}
   m_CullTransparentMesh: 0
 --- !u!1 &1797048304
 GameObject:

--- a/Assets/Scripts/Dialogue/LoadUniversalDialogue.cs
+++ b/Assets/Scripts/Dialogue/LoadUniversalDialogue.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Yarn.Unity;
+
+/// <summary>
+/// This class/script is used in the Environment GameObject for the
+/// purpose of loading up all of the yarn scripts that is used
+/// in most, if not all, of the Unity Scenes. This script is disabled
+/// after it calls its <c>void Update()</c> function once.
+/// </summary>
+[System.Obsolete("This script should not be used until an actual use can be " +
+    "found for this. The main reason is because it is much easier to add " +
+    "YarnPrograms via the DialogueRunner in the Inspector.", false)]
+public class LoadUniversalDialogue : MonoBehaviour
+{
+    /// <summary>
+    /// DialogueRunner object to add scripts to. This is initialized in the
+    /// void Start() function.
+    /// </summary>
+    private DialogueRunner dialogueRunner;
+
+    /// <summary>
+    /// List of the YarnPrograms that should be residing in the directory,
+    /// <c>Assets/Scripts/Dialogue/Resources</c>, without the .yarn extension
+    /// at the end.
+    /// <para/>
+    /// To add a new Universal YarnProgram file, add it to the
+    /// <c>Assets/Scripts/Dialogue/Resources</c> directory. Then, in this 
+    /// collection initializer, add the name of the YarnProgram file without
+    /// the .yarn extension. Be sure to add a comma right after the previous
+    /// YarnProgram filename.
+    /// </summary>
+    private readonly List<string> universalYarnProgramFilenames = new List<string>
+    {
+        "TrashItem"
+    };
+
+    /// <summary>
+    /// This function will initialize the DialogueRunner object
+    /// </summary>
+    void Start()
+    {
+        dialogueRunner = FindObjectOfType<DialogueRunner>();
+    }
+
+    /// <summary>
+    /// This function will add all of the YarnPrograms based off of
+    /// the filenames in the List field, universalYarnProgramFilenames.
+    /// Then, it will be disabled.
+    /// </summary>
+    void Update()
+    {
+        if (!dialogueRunner) // if dialogue runner was not found
+        {
+            Debug.LogError("LoadUniversalDialogue.cs: DialogueRunner was not found! No Universal YarnPrograms were added");
+        }
+        else // if dialogue runner was found
+        {
+            // Add the scripts listed in universalYarnProgramFilenames
+            foreach (string filename in universalYarnProgramFilenames)
+            {
+                Debug.Log(string.Format("Added {0}.yarn", filename));
+                dialogueRunner.Add(Resources.Load<YarnProgram>(filename));
+            }
+        }
+
+        // disable this script at the end
+        enabled = false;
+    }
+}

--- a/Assets/Scripts/Dialogue/LoadUniversalDialogue.cs.meta
+++ b/Assets/Scripts/Dialogue/LoadUniversalDialogue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec9b7db485b9db849911be3c313fd434
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Resources.meta
+++ b/Assets/Scripts/Dialogue/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 30f90f271503a6b4791d484c90612c50
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Resources/TrashItem.yarn
+++ b/Assets/Scripts/Dialogue/Resources/TrashItem.yarn
@@ -1,0 +1,26 @@
+﻿title: TrashItem
+tags:
+---
+<<ChangeSpeaker Player>>
+	Would you like to throw this away?
+	[[Throw it away.|TrashIt]]
+	[[Leave it alone.|PutitDown]]
+===
+
+title: TrashIt
+tags:
+---
+<<ChangeSpeaker Player>>
+	You threw it away.
+
+<<Trash Confirm>>
+<<stop>>
+===
+
+title: CannotTrash
+tags:
+---
+<<ChangeSpeaker Player>>
+  You can't throw this away.
+<<stop>>
+===

--- a/Assets/Scripts/Dialogue/Resources/TrashItem.yarn.meta
+++ b/Assets/Scripts/Dialogue/Resources/TrashItem.yarn.meta
@@ -1,0 +1,17 @@
+fileFormatVersion: 2
+guid: 4190cc03f81b55b438f24739cb205d17
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 94073015eacc34c1d8fc6786e43d60ca, type: 3}
+  baseLanguageID: en-US
+  stringIDs: []
+  compilationStatus: 0
+  isSuccesfullyCompiled: 1
+  compilationErrorMessage: 
+  baseLanguage: {instanceID: 0}
+  localizations: []

--- a/Assets/Scripts/Dialogue/YarnInventory.cs
+++ b/Assets/Scripts/Dialogue/YarnInventory.cs
@@ -27,6 +27,10 @@ public class YarnInventory : MonoBehaviour
         "Destroy",     // the name of the command
         DestroyObject // the method to run
         );
+        dialogueRunner.AddCommandHandler(
+        "Trash",
+        TrashInventory.DoTrashItem
+        );
     }
 
     private void AddtoInventory(string[] parameters)

--- a/Assets/Scripts/Inventory/TrashInventory.cs
+++ b/Assets/Scripts/Inventory/TrashInventory.cs
@@ -9,8 +9,8 @@ public class TrashInventory : MonoBehaviour, IPointerEnterHandler, IPointerExitH
 	// dialogue runner
 	public DialogueRunner dialogueRunner;
 
-	// current item ready to trash
-	private Item itemToTrash;
+	// current item ready to trash (static due to DoTrashItem function)
+	private static Item itemToTrash;
 
 	// Images for trash open and trash closed
 	public Sprite trashOpened = null;
@@ -18,18 +18,6 @@ public class TrashInventory : MonoBehaviour, IPointerEnterHandler, IPointerExitH
 
 	// affects what Image should be shown
 	private bool showOpenTrash = false;
-	
-	void Awake()
-	{
-		// add the trash command to DialogueRunner
-		if (dialogueRunner)
-		{
-			dialogueRunner.AddCommandHandler(
-				"Trash",
-				DoTrashItem
-			);
-		}
-	}
 
 	void Update()
 	{
@@ -77,7 +65,8 @@ public class TrashInventory : MonoBehaviour, IPointerEnterHandler, IPointerExitH
 	}
 
 	// Function that will trash the item
-	private void DoTrashItem(string[] parameters)
+	// This was made static so that YarnInventory.cs can call it.
+	public static void DoTrashItem(string[] parameters)
 	{
 		if (parameters[0] == "Confirm" && itemToTrash)
 		{

--- a/Assets/Scripts/Levels/coffee level/Yarn/Cup.yarn
+++ b/Assets/Scripts/Levels/coffee level/Yarn/Cup.yarn
@@ -145,22 +145,3 @@ tags:
 <<HidePanel AddCream>>
 <<stop>>
 ===
-
-title: TrashItem
-tags:
----
-<<ChangeSpeaker Player>>
-	Would you like to throw this away?
-	[[Throw it away.|TrashIt]]
-	[[Leave it alone.|PutitDown]]
-===
-title: TrashIt
-tags:
----
-<<ChangeSpeaker Player>>
-	You threw it away.
-
-<<Trash Confirm>>
-<<stop>>
-===
-


### PR DESCRIPTION
TrashInventory.cs
- Removed the call to DialogueRunner.AddCommandHandler(...) to move it
to YarnInventory.cs
- Made itemToTrash and DoTrashItem(...) to be static so that it can be
called in YarnInventory.cs

YarnInventory.cs
- Added new Yarn Command here, "Trash", which calls
TrashInventory.DoTrashItem

TrashItem.yarn and Cup.yarn
- Removed the Trash-related dialogue from Cup.yarn, and moved it to
TrashItem.yarn.
- Created TrashItem.yarn which is located in
Assets/Scripts/Dialogue/Resources

Tutorial.unity
- Added TrashItem to Yarn Scripts
- Added Trash Slot GameObject, copied from CoffeeScene.unity
-- Trash Image GameObject was also added here

CoffeeScene.unity
- Added Sound Manager here (bugfix)
- Added TrashItem yarnScript to the dialogue runner

LoadUniversalDialogue.cs (ALREADY DEPRECATED)
- Created and Deprecated this script
- just keeping track of it just in case there is some need for it