### PR TITLE
Key item feature and CoffeePuzzle state reset

### DIFF
--- a/Assets/Scenes/CoffeeScene.unity
+++ b/Assets/Scenes/CoffeeScene.unity
@@ -4148,11 +4148,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   puzzlePanel: {fileID: 1087914911}
   CustomVariableStorage: {fileID: 1124219127}
-  cupThere: 1
-  filterThere: 1
-  groundsThere: 1
+  cupThere: 0
+  filterThere: 0
+  groundsThere: 0
   brewed: 0
-  lidThere: 1
+  lidThere: 0
   cup: {fileID: 850437287}
   filter: {fileID: 1717848867}
   grounds: {fileID: 107685511}

--- a/Assets/Scenes/Tutorial.unity
+++ b/Assets/Scenes/Tutorial.unity
@@ -727,7 +727,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b6fc19c3f2be7b418b8135d193ce996, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  item: {fileID: 11400000, guid: 2836a159a0224a243b2366e5527a0786, type: 2}
+  item: {fileID: 11400000, guid: 6551a0d8c49781842824dde9509e7e48, type: 2}
   player: {fileID: 2875367029536886229}
   coffee: 0
   dialogueRunner: {fileID: 739597929}
@@ -2499,7 +2499,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b6fc19c3f2be7b418b8135d193ce996, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  item: {fileID: 11400000, guid: 3011e99c097b9034985f4e0ddba58782, type: 2}
+  item: {fileID: 11400000, guid: 9ce05420b875c1f46bce8bcc16a82e48, type: 2}
   player: {fileID: 2875367029536886229}
   coffee: 0
   dialogueRunner: {fileID: 739597929}
@@ -3507,7 +3507,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b6fc19c3f2be7b418b8135d193ce996, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  item: {fileID: 11400000, guid: 2ea6d8ba091f4644e948950ebfa71490, type: 2}
+  item: {fileID: 11400000, guid: 6564d1dc15319214893b552e2d8424de, type: 2}
   player: {fileID: 2875367029536886229}
   coffee: 0
   dialogueRunner: {fileID: 739597929}
@@ -3647,7 +3647,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b6fc19c3f2be7b418b8135d193ce996, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  item: {fileID: 11400000, guid: bde29424c08ed524f98ed3134d053e5f, type: 2}
+  item: {fileID: 11400000, guid: 7defff0feb8dbba40b1455459bc24a70, type: 2}
   player: {fileID: 2875367029536886229}
   coffee: 0
   dialogueRunner: {fileID: 739597929}

--- a/Assets/Scripts/Inventory/KeyItem.cs
+++ b/Assets/Scripts/Inventory/KeyItem.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "new Key Item", menuName = "Items/Key Item")]
+public class KeyItem : Item
+{
+
+}

--- a/Assets/Scripts/Inventory/KeyItem.cs.meta
+++ b/Assets/Scripts/Inventory/KeyItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 656195c6c6d4f4b4eb0a72317b35c46e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Inventory/TrashInventory.cs
+++ b/Assets/Scripts/Inventory/TrashInventory.cs
@@ -58,7 +58,8 @@ public class TrashInventory : MonoBehaviour, IPointerEnterHandler, IPointerExitH
 		{
 			// line of code used from InventorySlot.OnDrop
 			itemToTrash = Inventory.instance.itemList[eventData.pointerDrag.GetComponent<ItemDragHandler>().transform.parent.GetSiblingIndex()];
-			dialogueRunner.StartDialogue("TrashItem");
+			// If KeyItem, do not trash. Otherwise, give trash option.
+			dialogueRunner.StartDialogue((itemToTrash is KeyItem)?"CannotTrash":"TrashItem");
 		}
 		// Set trash to be closed
 		showOpenTrash = false;

--- a/Assets/Scripts/Levels/Tutorial/FlowerA.asset
+++ b/Assets/Scripts/Levels/Tutorial/FlowerA.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfb260ee78c558440961cc09e4521b96, type: 3}
+  m_Script: {fileID: 11500000, guid: 656195c6c6d4f4b4eb0a72317b35c46e, type: 3}
   m_Name: FlowerA
   m_EditorClassIdentifier: 
   itemName: FlowerA

--- a/Assets/Scripts/Levels/Tutorial/FlowerA.asset.meta
+++ b/Assets/Scripts/Levels/Tutorial/FlowerA.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2836a159a0224a243b2366e5527a0786
+guid: 6551a0d8c49781842824dde9509e7e48
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/Assets/Scripts/Levels/Tutorial/FlowerB.asset
+++ b/Assets/Scripts/Levels/Tutorial/FlowerB.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfb260ee78c558440961cc09e4521b96, type: 3}
+  m_Script: {fileID: 11500000, guid: 656195c6c6d4f4b4eb0a72317b35c46e, type: 3}
   m_Name: FlowerB
   m_EditorClassIdentifier: 
   itemName: FlowerB

--- a/Assets/Scripts/Levels/Tutorial/FlowerB.asset.meta
+++ b/Assets/Scripts/Levels/Tutorial/FlowerB.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bde29424c08ed524f98ed3134d053e5f
+guid: 7defff0feb8dbba40b1455459bc24a70
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/Assets/Scripts/Levels/Tutorial/FlowerC.asset
+++ b/Assets/Scripts/Levels/Tutorial/FlowerC.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfb260ee78c558440961cc09e4521b96, type: 3}
+  m_Script: {fileID: 11500000, guid: 656195c6c6d4f4b4eb0a72317b35c46e, type: 3}
   m_Name: FlowerC
   m_EditorClassIdentifier: 
   itemName: FlowerC

--- a/Assets/Scripts/Levels/Tutorial/FlowerC.asset.meta
+++ b/Assets/Scripts/Levels/Tutorial/FlowerC.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2ea6d8ba091f4644e948950ebfa71490
+guid: 6564d1dc15319214893b552e2d8424de
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/Assets/Scripts/Levels/Tutorial/FlowerD.asset
+++ b/Assets/Scripts/Levels/Tutorial/FlowerD.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfb260ee78c558440961cc09e4521b96, type: 3}
+  m_Script: {fileID: 11500000, guid: 656195c6c6d4f4b4eb0a72317b35c46e, type: 3}
   m_Name: FlowerD
   m_EditorClassIdentifier: 
   itemName: FlowerD

--- a/Assets/Scripts/Levels/Tutorial/FlowerD.asset.meta
+++ b/Assets/Scripts/Levels/Tutorial/FlowerD.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3011e99c097b9034985f4e0ddba58782
+guid: 9ce05420b875c1f46bce8bcc16a82e48
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/Assets/Scripts/Levels/Tutorial/Key.asset
+++ b/Assets/Scripts/Levels/Tutorial/Key.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfb260ee78c558440961cc09e4521b96, type: 3}
+  m_Script: {fileID: 11500000, guid: 656195c6c6d4f4b4eb0a72317b35c46e, type: 3}
   m_Name: Key
   m_EditorClassIdentifier: 
   itemName: Key

--- a/Assets/Scripts/Levels/Tutorial/Key.asset.meta
+++ b/Assets/Scripts/Levels/Tutorial/Key.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 767d093321092ac439c95c1212fff4fb
+guid: 72b96f69cb013334d9e62b71a7e96363
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0


### PR DESCRIPTION
- Added KeyItem to be used in the Tutorial (flowers and the key are now of type KeyItem). Trash will not allow the player to throw away anything of type KeyItem.
- Also made the CoffeeScene puzzle to be set to its default state (before, it skipped steps for easier debugging)