### PR TITLE
In Hide/ShowPuzzle, I added a boolean in each script (they are separa…

### DIFF
--- a/Assets/Scenes/ArcadeScene.unity
+++ b/Assets/Scenes/ArcadeScene.unity
@@ -466,6 +466,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   puzzlePanel: {fileID: 46273286}
   DoNotOpenInventory: 1
+  stopPlayerMovement: 1
 --- !u!1 &54726286
 GameObject:
   m_ObjectHideFlags: 0
@@ -6557,6 +6558,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   puzzlePanel: {fileID: 1544622799}
   RemoveButton: {fileID: 799109178}
+  allowPlayerMovement: 1
 --- !u!114 &799109180
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7884,6 +7886,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   puzzlePanel: {fileID: 946286739}
   DoNotOpenInventory: 1
+  stopPlayerMovement: 1
 --- !u!224 &947311911 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7293306742847872400, guid: 4d6c0d0a198aef6458e73288cb651665,
@@ -8009,6 +8012,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   puzzlePanel: {fileID: 946286739}
   RemoveButton: {fileID: 947627346}
+  allowPlayerMovement: 1
 --- !u!114 &947627348
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12812,6 +12816,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   puzzlePanel: {fileID: 1544622799}
   DoNotOpenInventory: 1
+  stopPlayerMovement: 1
 --- !u!1 &1565046119
 GameObject:
   m_ObjectHideFlags: 0
@@ -16939,6 +16944,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   puzzlePanel: {fileID: 46273286}
   RemoveButton: {fileID: 2061025700}
+  allowPlayerMovement: 1
 --- !u!114 &2061025702
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Levels/HidePuzzle.cs
+++ b/Assets/Scripts/Levels/HidePuzzle.cs
@@ -2,11 +2,15 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using Yarn.Unity;
 
 public class HidePuzzle : MonoBehaviour
 {
     public GameObject puzzlePanel;
     public Button RemoveButton;
+
+    [Tooltip("Restart's the player's movement when a puzzle is hidden")]
+    public bool allowPlayerMovement = false; // boolean to see if Hide() allows player movement
 
     public void Hide()
     {
@@ -18,6 +22,28 @@ public class HidePuzzle : MonoBehaviour
         {
             blocker.GetComponent<CanvasGroup>().alpha = 0;
             blocker.GetComponent<CanvasGroup>().blocksRaycasts = false;
+        }
+
+        // do allow player movement
+        GameObject playerGameObject = GameObject.Find("Player");
+        if (allowPlayerMovement && playerGameObject)
+        {
+            Player player = playerGameObject.GetComponent<Player>();
+            if (player)
+            {
+                player.AllowMove(true);
+            }
+        }
+        else if (!allowPlayerMovement && playerGameObject) // Warning if the player is not allowed to move when Hide() was called
+        {
+            Player player = playerGameObject.GetComponent<Player>();
+            if (player && !player.allowMovement)
+            {
+                Debug.LogWarning(string.Format("HidePuzzle.cs: A puzzle panel was hidden, but the " +
+                    "player was not allowed to move because the boolean" +
+                    "'Allow Player Movement' was set to false for this puzzle panel. If this was not " +
+                    "intended, then make sure to check this in the inspector."));
+            }
         }
     }
 }

--- a/Assets/Scripts/Levels/ShowPuzzle.cs
+++ b/Assets/Scripts/Levels/ShowPuzzle.cs
@@ -8,6 +8,9 @@ public class ShowPuzzle : MonoBehaviour
     public GameObject puzzlePanel;
     public bool DoNotOpenInventory = false;
 
+    [Tooltip("Stop the player's movement when a puzzle is shown")]
+    public bool stopPlayerMovement = false; // used in Update()
+
     [YarnCommand("Show")]
     public void Puzzle()
     {
@@ -45,6 +48,31 @@ public class ShowPuzzle : MonoBehaviour
                 if (playerScript && !playerScript.invActive)
                 {
                     playerScript.activateMenu();
+                }
+            }
+        }
+    }
+
+    // make private reference to the player gameobject for use in Update()
+    private GameObject playerGameObject; // this is set in Awake()
+    void Awake()
+    {
+        playerGameObject = GameObject.Find("Player");
+    }
+    void Update()
+    {
+        // if we want to stop the player movement, check if a puzzle panel is opened...
+        if (stopPlayerMovement &&
+            puzzlePanel.GetComponent<CanvasGroup>() &&
+            puzzlePanel.GetComponent<CanvasGroup>().alpha == 1)
+        {
+            // ...then get a player object and then set AllowMove to false
+            if (stopPlayerMovement && playerGameObject)
+            {
+                Player player = playerGameObject.GetComponent<Player>();
+                if (player && player.allowMovement)
+                {
+                    player.AllowMove(false);
                 }
             }
         }


### PR DESCRIPTION
…te) to decide whether these scripts are responsible for affecting player movement (i.e. a puzzle being shown results in player movement being not allowed). In essence, there should be a pair of checked booleans if a puzzle should restrict/allow movement when a puzzle is shown or hidden, respectively.