### PR TITLE
Expressions Update

### DIFF
--- a/Assets/Scenes/DialogueUpdateScene.unity
+++ b/Assets/Scenes/DialogueUpdateScene.unity
@@ -1470,7 +1470,7 @@ PrefabInstance:
     - target: {fileID: 720895104263553551, guid: 32ecd2b4f32066d48bd773fa364541a0,
         type: 3}
       propertyPath: yarnScripts.Array.size
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 720895104263553551, guid: 32ecd2b4f32066d48bd773fa364541a0,
         type: 3}
@@ -1496,7 +1496,7 @@ PrefabInstance:
     - target: {fileID: 720895104263553551, guid: 32ecd2b4f32066d48bd773fa364541a0,
         type: 3}
       propertyPath: startNode
-      value: RichText_Dialogue
+      value: Expressions_Dialogue
       objectReference: {fileID: 0}
     - target: {fileID: 720895104263553551, guid: 32ecd2b4f32066d48bd773fa364541a0,
         type: 3}
@@ -1524,6 +1524,12 @@ PrefabInstance:
       propertyPath: onNodeStart.m_PersistentCalls.m_Calls.Array.data[4].m_Target
       value: 
       objectReference: {fileID: 1652993302}
+    - target: {fileID: 720895104263553551, guid: 32ecd2b4f32066d48bd773fa364541a0,
+        type: 3}
+      propertyPath: yarnScripts.Array.data[3]
+      value: 
+      objectReference: {fileID: 2480198943629176163, guid: c9adc1e0bcb56514f8e2aaa3eae86174,
+        type: 3}
     - target: {fileID: 720895104907229992, guid: 32ecd2b4f32066d48bd773fa364541a0,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/Dialogue/CharacterObj.cs
+++ b/Assets/Scripts/Dialogue/CharacterObj.cs
@@ -6,5 +6,55 @@ using UnityEngine;
 public class CharacterObj : ScriptableObject
 {
 	public string characterName;
-	public Sprite defaultSprite;
+	[Tooltip("Also used as the neutral expression")]
+	public Sprite defaultSprite; // also known as neutral
+
+	// More expressions that can possibly be used, but will fallback to default sprite if needed.
+	//		If new expressions are added, place them here and update GetExpression to handle it.
+	public Sprite angrySprite;
+	public Sprite happySprite;
+	public Sprite hmmSprite;
+	public Sprite shockedSprite;
+
+	// Retrieves the requested expression (or the default sprite, if not set)
+	public Sprite GetExpression(string expression)
+	{
+		// switch-case with the name but in lowercase to prevent possible issues
+		switch (expression.ToLower())
+		{
+			case "angry":
+				return VerifySprite(angrySprite);
+
+			case "happy":
+				return VerifySprite(happySprite);
+
+			case "hmm":
+				return VerifySprite(hmmSprite);
+
+			case "shock":
+			case "shocked":
+				return VerifySprite(shockedSprite);
+
+			// defaultSprite will be used if these keywords are specified, or if the requested expression is unavailable
+			case "default":
+			case "neutral":
+			default:
+				return defaultSprite;
+		}
+	}
+
+	// Helper function that checks if the sprite is null. It will either return itself, or the default sprite
+	private Sprite VerifySprite(Sprite sprite)
+	{
+		// return defaultSprite if the requested sprite is null
+		if (sprite == null)
+		{
+			return defaultSprite;
+		}
+		// otherwise, return the sprite
+		else
+		{
+			return sprite;
+		}
+	}
 }

--- a/Assets/Scripts/Dialogue/Resources/Characters/Friend.asset
+++ b/Assets/Scripts/Dialogue/Resources/Characters/Friend.asset
@@ -14,3 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterName: Fredric
   defaultSprite: {fileID: 21300000, guid: ba6f54d8f8d1fbe4eaeb7e3471180d4d, type: 3}
+  angrySprite: {fileID: 21300000, guid: 7e2c861a84e80de4ab926583919e6ef4, type: 3}
+  happySprite: {fileID: 21300000, guid: c670f0434389f2f42be77e15120bcff4, type: 3}
+  hmmSprite: {fileID: 21300000, guid: 626aa2d4c32357d4187ffaa2b6fc60e6, type: 3}
+  shockedSprite: {fileID: 21300000, guid: 6c305bfc964ecb846860bce924a96dc4, type: 3}

--- a/Assets/Scripts/Dialogue/Resources/Characters/Gravekeeper.asset
+++ b/Assets/Scripts/Dialogue/Resources/Characters/Gravekeeper.asset
@@ -14,3 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterName: Gravekeeper
   defaultSprite: {fileID: 21300000, guid: ec145b6c7b856904bab4055b9726764b, type: 3}
+  angrySprite: {fileID: 0}
+  happySprite: {fileID: 21300000, guid: e3d03e012af1f9248be887151d2218f0, type: 3}
+  hmmSprite: {fileID: 0}
+  shockedSprite: {fileID: 21300000, guid: 814b0fe01b155b74e8aeff0f0a52bf59, type: 3}

--- a/Assets/Scripts/Levels/DialogueUpdateScene/Yarn/Expressions Dialogue.yarn
+++ b/Assets/Scripts/Levels/DialogueUpdateScene/Yarn/Expressions Dialogue.yarn
@@ -1,0 +1,130 @@
+﻿title: Expressions_Dialogue
+tags:
+---
+<<ChangeSpeaker Friend Gravekeeper>>
+<<Focus NONE>>
+    Now beginning the expressions test.
+
+[[SingleParam]]
+===
+
+title: SingleParam
+tags:
+---
+<<ChangeSpeaker Friend Gravekeeper>>
+<<Focus NONE>>
+    This test involves changing the expression with SetExpression using a single parameter. This means that it will change the expression of the person in focus.
+
+<<Focus FIRST>>
+    Woah. You know what?
+
+<<Focus SECOND>>
+    What?
+
+<<Focus FIRST>>
+<<SetExpression angry>>
+    I'm feeling <color=red>angry</color>!
+
+<<Focus SECOND>>
+<<SetExpression shocked>>
+    Woah, Fredric, you alright? Your outburst scared me.
+
+<<Focus FIRST>>
+    I'm just feeling really angry! In fact, I'm feeling many emotions.
+<<SetExpression hmm>>
+    Let's see what kind of emotions...
+<<SetExpression happy>>
+    I can feel happy.
+<<SetExpression shocked>>
+    Or be scared like you were earlier.
+<<SetExpression neutral>>
+    Or not feel anything at all.
+
+<<Focus SECOND>>
+<<SetExpression happy>>
+    Well if you're happy, then I'm fine with that. So just stick to being happy.
+
+[[DoubleParam]]
+===
+
+title: DoubleParam
+tags:
+---
+<<ChangeSpeaker Gravekeeper Friend>>
+<<Focus NONE>>
+    This test will now use two parameters when changing expression. The first parameter is the character's name/FIRST/SECOND, and the second is the expression.
+
+<<Focus FIRST>>
+<<SetExpression Gravekeeper happy>>
+    Hey Fredric. Glad to see that you're okay.
+<<SetExpression Gravekeeper neutral>>
+<<SetExpression Fredric angry>>
+    ... Or are you?
+<<SetExpression Fredric hmm>>
+    Geez, you're making lots of weird faces.
+
+<<Focus SECOND>>
+<<SetExpression Fredric shocked>>
+    AAH! Oh, sorry, what were you saying?
+
+<<Focus FIRST>>
+<<SetExpression Gravekeeper neutral>>
+    Oh, nothing. Keep doing what you were doing...
+
+[[StressTest]]
+===
+
+title: StressTest
+tags:
+---
+<<ChangeSpeaker Friend Gravekeeper>>
+<<Focus NONE>>
+    This is a stress test, designed to ensure that any possible issues are properly tested. The dialogue will no longer be actual dialogue, but will reference what is being tested.
+
+<<Focus BOTH>>
+<<SetExpression neutral>>
+    Both neutral (should do nothing)
+<<SetExpression shocked>>
+    Both shocked
+
+<<Focus Gravekeeper>>
+<<SetExpression Gravekeeper angry>>
+    Double param angry (should have gravekeeper be neutral still, and have fredric not changing their expression)
+<<SetExpression neutral>>
+    Single param angry (should have gravekeeper be neutral still, and have fredric not changing their expression)
+
+<<Focus FIRST>>
+<<SetExpression neutral>>
+    Friend should have neutral expression
+
+<<SetExpression asdfghjkl>>
+    Changing expression to asdfghjkl (i.e., should remain neutral)
+
+<<SetExpression neutral>>
+    Changing expression back to neutral.
+
+<<SetExpression angry>>
+    Changing expression to angry.
+
+<<SetExpression zxcvbnm>>
+    Changing expression to zxcvbnm (i.e., should become neutral from angry)
+
+<<Focus NONE>>
+    Now no one will be in focus.
+<<SetExpression shocked>>
+    Setting expression to shocked should not set anyone to be shocked
+<<SetExpression Gravekeeper shocked>>
+    Gravekeeper set to shocked
+<<SetExpression Fredric happy>>
+    Fredric set to happy
+<<SetExpression asdfghjkl>>
+    Setting general (single-param) expression to asdfghjkl (should do nothing).
+
+[[ExpressionTestConclusion]]
+===
+
+title: ExpressionTestConclusion
+---
+<<ChangeSpeaker Player>>
+    This concludes the expressions test.
+===

--- a/Assets/Scripts/Levels/DialogueUpdateScene/Yarn/Expressions Dialogue.yarn.meta
+++ b/Assets/Scripts/Levels/DialogueUpdateScene/Yarn/Expressions Dialogue.yarn.meta
@@ -1,0 +1,17 @@
+fileFormatVersion: 2
+guid: c9adc1e0bcb56514f8e2aaa3eae86174
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 94073015eacc34c1d8fc6786e43d60ca, type: 3}
+  baseLanguageID: en-US
+  stringIDs: []
+  compilationStatus: 0
+  isSuccesfullyCompiled: 1
+  compilationErrorMessage: 
+  baseLanguage: {instanceID: 0}
+  localizations: []


### PR DESCRIPTION
CharacterObj:
- Now supports the following expressions: angry, happy, hmm,
shocked/shock, default/neutral
- Has a GetExpression function that can translate a string expression
into its corresponding sprite, and it will return the corresponding
sprite (or the default sprite if the requested expression does not exist
or is not set for the character).

SetExpression YarnCommand (in ChangeSpeaker.cs)
- Syntax: <<SetExpression (name of character) expression>>
- Sets the expression of the specified character or, if the character is
not specified, the character in focus